### PR TITLE
Add compatibility with Python3

### DIFF
--- a/pybfd/bfd.c
+++ b/pybfd/bfd.c
@@ -1331,7 +1331,7 @@ static struct PyModuleDef _bfd_module = {
 //
 // Returns  : -
 //
-PyMODINIT_FUNC 
+PyMODINIT_FUNC
 #if PY_MAJOR_VERSION >= 3
 PyInit__bfd(void) {
 #else

--- a/pybfd/bfd.c
+++ b/pybfd/bfd.c
@@ -596,6 +596,8 @@ pybfd_get_sections_list(PyObject *self, PyObject *args) {
                 return NULL;
 
             for (section = abfd->sections; section; section = section->next) {
+                if (!section)
+			break;
                 PyList_SetItem(list, section->index, Py_BuildValue("n", section));
             }
 
@@ -1306,6 +1308,20 @@ static struct PyMethodDef _bfd_methods[] = {
 #undef declmethod
 };
 
+#if PY_MAJOR_VERSION >= 3
+static struct PyModuleDef _bfd_module = {
+	PyModuleDef_HEAD_INIT,
+	"_bfd",					/* m_name */
+	"The binding for libBFD from binutils",	/* m_doc */
+	-1,					/* m_size */
+	_bfd_methods, 				/* m_methods */
+	NULL,					/* m_reload */
+	NULL,					/* m_traverse */
+	NULL,					/* m_clear */
+	NULL,					/* m_free */
+};
+#endif
+
 //
 // Name     : init_pybfd
 //
@@ -1315,10 +1331,33 @@ static struct PyMethodDef _bfd_methods[] = {
 //
 // Returns  : -
 //
-PyMODINIT_FUNC init_bfd(void) {
-    if (!Py_InitModule("_bfd", _bfd_methods))
+PyMODINIT_FUNC 
+#if PY_MAJOR_VERSION >= 3
+PyInit__bfd(void) {
+#else
+init_bfd(void) {
+#endif
+
+    PyObject *module = NULL;
+#if PY_MAJOR_VERSION >= 3
+    module = PyModule_Create(&_bfd_module);
+#else
+    module = Py_InitModule("_bfd", _bfd_methods);
+#endif
+    if (!module)
+    {
+#if PY_MAJOR_VERSION >= 3
+        return NULL;
+#else
         return;
+#endif
+    }
 
     // Initialize current library.
     initialize();
+#if PY_MAJOR_VERSION >= 3
+    return module;
+#else
+    return;
+#endif
 }

--- a/pybfd/bfd.py
+++ b/pybfd/bfd.py
@@ -35,10 +35,10 @@ else:
     import _bfd
 del version_info
 
-from bfd_archs import *
-from section import *
-from symbol import *
-from bfd_base import *
+from pybfd.bfd_archs import *
+from pybfd.section import *
+from pybfd.symbol import *
+from pybfd.bfd_base import *
 
 __author__ = "Groundworks Technologies OSS Team"
 __contact__ = "oss@groundworkstech.com"

--- a/pybfd/bfd.py
+++ b/pybfd/bfd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-# 
+#
 # Copyright (c) 2013 Groundworks Technologies
-# 
+#
 # This code is part PyBFD module (libbfd & libopcodes extension module)
 #
 
@@ -35,10 +35,10 @@ else:
     import _bfd
 del version_info
 
-from .bfd_archs import *
-from .section import *
-from .symbol import *
-from .bfd_base import *
+from bfd_archs import *
+from section import *
+from symbol import *
+from bfd_base import *
 
 __author__ = "Groundworks Technologies OSS Team"
 __contact__ = "oss@groundworkstech.com"
@@ -80,7 +80,7 @@ class Bfd(object):
     """
     Main BFD wrapper class. This class allows the user to handle a BFD object
     (open a file to get its symbols, read resction content, etc..
-    
+
     """
 
     DEFAULT_TARGET = "default"
@@ -125,7 +125,7 @@ class Bfd(object):
 
         @return : None
         """
-        # Close any existing BFD structure instance. 
+        # Close any existing BFD structure instance.
         self.close()
 
         #
@@ -139,7 +139,7 @@ class Bfd(object):
 
             if islink(filename):
                 raise BfdException("Symlinks file-descriptors are not valid")
-                    
+
             try:
                 self._ptr = _bfd.fdopenr(filename, target, dup(_file.fileno()))
             except Exception as err:
@@ -461,7 +461,7 @@ class Bfd(object):
         if self.big_endian:
             return ENDIAN_BIG
         elif self.little_endian:
-            return ENDIAN_LITTLE        
+            return ENDIAN_LITTLE
         return ENDIAN_UNKNOWN
 
     @property
@@ -498,7 +498,7 @@ class Bfd(object):
     def header_little_endian(self):
         """Return the header_little_endian attribute of the BFD file being
         processed.
-        
+
         """
         if not self._ptr:
             raise BfdException("BFD not initialized")
@@ -602,7 +602,7 @@ class Bfd(object):
     def start_address(self, _start_address):
         """Store the new start address attribute of the BFD file being
         processed.
-        
+
         """
         if not self._ptr:
             raise BfdException("BFD not initialized")
@@ -621,7 +621,7 @@ class Bfd(object):
     def gp_size(self, _gp_size):
         """Store the new start address attribute of the BFD file being
         processed.
-        
+
         """
         if not self._ptr:
             raise BfdException("BFD not initialized")
@@ -661,7 +661,7 @@ class Bfd(object):
     def dynamic_symbols_count(self):
         """Return the dynamic symbols count attribute of the BFD file being
         processed.
-        
+
         """
         if not self._ptr:
             raise BfdException("BFD not initialized")
@@ -673,7 +673,7 @@ class Bfd(object):
     def symbol_leading_char(self):
         """Return the symbol leading char attribute of the BFD file being
         processed.
-        
+
         """
         if not self._ptr:
             raise BfdException("BFD not initialized")
@@ -848,7 +848,7 @@ def main():
             except TypeError as err:
                 pass
 
-            # Release the current BFD and leave. 
+            # Release the current BFD and leave.
             bfd.close()
 
 if __name__ == "__main__":

--- a/pybfd/bfd_base.py
+++ b/pybfd/bfd_base.py
@@ -1,10 +1,10 @@
-# 
+#
 # Copyright (c) 2013 Groundworks Technologies
-# 
+#
 # This code is part PyBFD module (libbfd & libopcodes extension module)
 #
 
-from .bfd_archs import *
+from bfd_archs import *
 from six.moves import range
 from six.moves import zip
 

--- a/pybfd/bfd_base.py
+++ b/pybfd/bfd_base.py
@@ -4,7 +4,7 @@
 # This code is part PyBFD module (libbfd & libopcodes extension module)
 #
 
-from bfd_archs import *
+from pybfd.bfd_archs import *
 from six.moves import range
 from six.moves import zip
 

--- a/pybfd/bfd_base.py
+++ b/pybfd/bfd_base.py
@@ -4,7 +4,9 @@
 # This code is part PyBFD module (libbfd & libopcodes extension module)
 #
 
-from bfd_archs import *
+from .bfd_archs import *
+from six.moves import range
+from six.moves import zip
 
 
 class BfdFormat:
@@ -224,7 +226,7 @@ INSTRUCTION_ATTRIBUTES = (
 )
 
 def enum(*sequential, **named):
-    enums = dict(zip(sequential, range(len(sequential))), **named)
+    enums = dict(list(zip(sequential, list(range(len(sequential))))), **named)
     return type('Enum', (), enums)
 
 

--- a/pybfd/gen_supported_disasm.py
+++ b/pybfd/gen_supported_disasm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # 
 # Copyright (c) 2013 Groundworks Technologies
 # 
@@ -9,7 +9,7 @@ import sys
 import os
 import re
 import subprocess
-from StringIO import StringIO
+import io
 
 __all__ = [ "generate_supported_disassembler_header",
             "generate_supported_architectures_source",
@@ -262,7 +262,7 @@ def get_supported_architectures(path_to_nm, path_to_libopcodes, supported_machin
 
     # Buffer the output.
     syms_found = set()
-    output = StringIO(stdout)
+    output = io.StringIO(stdout.decode('utf-8'))
 
     for line in output.getvalue().split("\n"):
         m = sym_expr.search( line )

--- a/pybfd/objdump.py
+++ b/pybfd/objdump.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-# 
+#
 # Copyright (c) 2013 Groundworks Technologies
-# 
+#
 # This code is part Python pybfd module (libbfd & libopcodes extension module)
 #
 
@@ -9,12 +9,12 @@ from sys import argv, exit
 from argparse import ArgumentParser, FileType, REMAINDER, Action
 from textwrap import dedent
 
-from . import bfd
-from bfd_archs import *
-from .bfd_base import *
-from .opcodes import *
-from .section import *
-from .symbol import SYMBOL_FLAGS_NAMES_SHORT
+from pybfb import bfd
+from pybfd.bfd_archs import *
+from pybfd.bfd_base import *
+from pybfd.opcodes import *
+from pybfd.section import *
+from pybfd.symbol import SYMBOL_FLAGS_NAMES_SHORT
 import six
 from six.moves import range
 

--- a/pybfd/opcodes.c
+++ b/pybfd/opcodes.c
@@ -479,7 +479,7 @@ start_smart_disassemble(disassembler_pointer* pdisasm_ptr, unsigned long offset,
             return -1;
         }
 
-        callback_result = PyInt_AS_LONG(py_result);
+        callback_result = PyLong_AsLong(py_result);
 
         if (callback_result != PYBFD_DISASM_CONTINUE)
             break;
@@ -1017,6 +1017,20 @@ static struct PyMethodDef _opcodes_methods[] =
 #undef declmethod
 };
 
+#if PY_MAJOR_VERSION >= 3
+static struct PyModuleDef _opcodes_module = {
+	PyModuleDef_HEAD_INIT,
+	"_opcodes",				/* m_name */
+	"The binding for libBFD from binutils",	/* m_doc */
+	-1,					/* m_size */
+	_opcodes_methods,			/* m_methods */
+	NULL,					/* m_reload */
+	NULL,					/* m_traverse */
+	NULL,					/* m_clear */
+	NULL,					/* m_free */
+};
+#endif
+
 //
 // Name     : init_opcodes
 //
@@ -1026,10 +1040,30 @@ static struct PyMethodDef _opcodes_methods[] =
 //
 // Returns  : -
 //
-PyMODINIT_FUNC init_opcodes(void)
-{
-    if (!Py_InitModule("_opcodes", _opcodes_methods))
+PyMODINIT_FUNC
+#if PY_MAJOR_VERSION >= 3
+PyInit__opcodes(void) {
+#else
+init_opcodes(void) {
+#endif
+    PyObject *module = NULL;
+#if PY_MAJOR_VERSION >= 3
+    module = PyModule_Create(&_opcodes_module);
+#else
+    module = Py_InitModule("_opcodes", _opcodes_methods);
+#endif
+    if (!module)
+    {
+#if PY_MAJOR_VERSION >= 3
+        return NULL;
+#else
         return;
+#endif
+    }
 
-    // Add additional initialization here.
+#if PY_MAJOR_VERSION >= 3
+    return module;
+#else
+    return;
+#endif
 }

--- a/pybfd/opcodes.py
+++ b/pybfd/opcodes.py
@@ -31,8 +31,8 @@ else:
     import _opcodes
 del version_info
 
-from bfd_archs import *
-from bfd_base import *
+from pybfd.bfd_archs import *
+from pybfd.bfd_base import *
 
 __author__      = "Groundworks Technologies OSS Team"
 __contact__     = "oss@groundworkstech.com"

--- a/pybfd/opcodes.py
+++ b/pybfd/opcodes.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-# 
+#
 # Copyright (c) 2013 Groundworks Technologies
-# 
+#
 # This code is part PyBFD module (libbfd & libopcodes extension module)
 #
 
@@ -32,7 +32,7 @@ else:
 del version_info
 
 from bfd_archs import *
-from .bfd_base import *
+from bfd_base import *
 
 __author__      = "Groundworks Technologies OSS Team"
 __contact__     = "oss@groundworkstech.com"
@@ -70,7 +70,7 @@ class Opcodes(object):
 
         # Determine if the specified paramter is a BFD or a tuple specifying
         # arch/machine/endian.
-        try:            
+        try:
             # FIXME: why we don't use isintance?
             if args[0].__class__.__name__ == "Bfd":
                 self.initialize_bfd(args[0])
@@ -83,7 +83,7 @@ class Opcodes(object):
 
     def initialize_bfd(self, abfd):
         """Initialize underlying libOpcodes library using BFD."""
-        self._ptr = _opcodes.initialize_bfd(abfd._ptr)              
+        self._ptr = _opcodes.initialize_bfd(abfd._ptr)
 
         # Already done inside opcodes.c
         #self.architecture = abfd.architecture
@@ -114,7 +114,7 @@ class Opcodes(object):
         """
         Set the binary buffer to disassemble with other related information
         ready for an instruction by instruction disassembly session.
-        
+
         """
         _opcodes.initialize_smart_disassemble(
             self._ptr, data, start_address)
@@ -132,7 +132,7 @@ class Opcodes(object):
         insn_type, target, target2, disassembly):
         """
         Callack on each disassembled instruction to print its information.
-        
+
         """
         print("0x%X SZ=%d BD=%d IT=%d\t%s" % \
             (address, size, branch_delay_insn, insn_type, disassembly))
@@ -143,7 +143,7 @@ class Opcodes(object):
         """
         Return a list containing the virtual memory address, instruction length
         and disassembly code for the given binary buffer.
-        
+
         """
         return _opcodes.disassemble(self._ptr, data, start_address)
 
@@ -185,7 +185,7 @@ class Opcodes(object):
 
 def main():
     """Test case for simple opcode disassembly."""
-    test_targets = (    
+    test_targets = (
         [ARCH_I386, MACH_I386_I386_INTEL_SYNTAX, ENDIAN_MONO, "\x55\x89\xe5\xE8\xB8\xFF\xFF\xFF", 0x1000],
         [ARCH_I386, MACH_X86_64_INTEL_SYNTAX, ENDIAN_MONO, "\x55\x48\x89\xe5\xE8\xA3\xFF\xFF\xFF", 0x1000],
         [ARCH_ARM, MACH_ARM_2, ENDIAN_LITTLE, "\x04\xe0\x2d\xe5\xED\xFF\xFF\xEB", 0x1000],

--- a/pybfd/opcodes.py
+++ b/pybfd/opcodes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # 
 # Copyright (c) 2013 Groundworks Technologies
 # 
@@ -32,7 +32,7 @@ else:
 del version_info
 
 from bfd_archs import *
-from bfd_base import *
+from .bfd_base import *
 
 __author__      = "Groundworks Technologies OSS Team"
 __contact__     = "oss@groundworkstech.com"
@@ -76,9 +76,9 @@ class Opcodes(object):
                 self.initialize_bfd(args[0])
             else:
                 self.initialize_non_bfd(*args)
-        except IndexError, err:
+        except IndexError as err:
             pass
-        except TypeError, err:
+        except TypeError as err:
             raise OpcodesException(err)
 
     def initialize_bfd(self, abfd):
@@ -134,8 +134,8 @@ class Opcodes(object):
         Callack on each disassembled instruction to print its information.
         
         """
-        print "0x%X SZ=%d BD=%d IT=%d\t%s" % \
-            (address, size, branch_delay_insn, insn_type, disassembly)
+        print("0x%X SZ=%d BD=%d IT=%d\t%s" % \
+            (address, size, branch_delay_insn, insn_type, disassembly))
 
         return PYBFD_DISASM_CONTINUE  # keep moving
 
@@ -201,14 +201,14 @@ def main():
         opcodes = Opcodes(target_arch, target_mach, target_endian)
 
         # Print some architecture-specific information.
-        print "\n[+] Architecture %s - Machine %d" % \
-            (opcodes.architecture_name, opcodes.machine)
+        print("\n[+] Architecture %s - Machine %d" % \
+            (opcodes.architecture_name, opcodes.machine))
 
-        print "[+] Disassembly:"
+        print("[+] Disassembly:")
 
         # Print all the disassembled instructions.
         for vma, size, disasm in opcodes.disassemble(binary, address):
-            print "0x%X (size=%d)\t %s" % (vma, size, disasm)
+            print("0x%X (size=%d)\t %s" % (vma, size, disasm))
 
 if __name__ == "__main__":
     main()

--- a/pybfd/section.py
+++ b/pybfd/section.py
@@ -4,8 +4,7 @@
 # This code is part Python pybfd module (libbfd extension module)
 #
 
-from bfd_base import BfdException, enum
-import _bfd
+from .bfd_base import BfdException, enum
 
 __author__      = "Groundworks Technologies OSS Team"
 __contact__     = "oss@groundworkstech.com"

--- a/pybfd/section.py
+++ b/pybfd/section.py
@@ -4,7 +4,7 @@
 # This code is part Python pybfd module (libbfd extension module)
 #
 
-from bfd_base import BfdException, enum
+from pybfd.bfd_base import BfdException, enum
 import _bfd
 
 __author__      = "Groundworks Technologies OSS Team"

--- a/pybfd/section.py
+++ b/pybfd/section.py
@@ -1,10 +1,11 @@
-# 
+#
 # Copyright (c) 2013 Groundworks Technologies
-# 
+#
 # This code is part Python pybfd module (libbfd extension module)
 #
 
-from .bfd_base import BfdException, enum
+from bfd_base import BfdException, enum
+import _bfd
 
 __author__      = "Groundworks Technologies OSS Team"
 __contact__     = "oss@groundworkstech.com"

--- a/pybfd/symbol.py
+++ b/pybfd/symbol.py
@@ -1,12 +1,12 @@
-# 
+#
 # Copyright (c) 2013 Groundworks Technologies
-# 
+#
 # This code is part PyBFD module (libbfd & libopcodes extension module)
 #
 
 from collections import namedtuple
 
-from .bfd_base import BfdException
+from bfd_base import BfdException
 
 __author__      = "Groundworks Technologies OSS Team"
 __contact__     = "oss@groundworkstech.com"

--- a/pybfd/symbol.py
+++ b/pybfd/symbol.py
@@ -6,7 +6,7 @@
 
 from collections import namedtuple
 
-from bfd_base import BfdException
+from .bfd_base import BfdException
 
 __author__      = "Groundworks Technologies OSS Team"
 __contact__     = "oss@groundworkstech.com"

--- a/pybfd/symbol.py
+++ b/pybfd/symbol.py
@@ -6,7 +6,7 @@
 
 from collections import namedtuple
 
-from bfd_base import BfdException
+from pybfd.bfd_base import BfdException
 
 __author__      = "Groundworks Technologies OSS Team"
 __contact__     = "oss@groundworkstech.com"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # 
 # Copyright (c) 2013 Groundworks Technologies
 # 
@@ -63,6 +63,17 @@ class InstallCustomCommandLine( install ):
 
 class CustomBuildExtension( build_ext ):
     PLATFORMS = {
+        "linux": {
+            "libs": [
+                "/usr/lib"
+            ],
+            "includes": [
+                "/usr/include"
+            ],
+            "possible-lib-ext": [
+                ".so",
+            ]
+        },
         "linux2": {
             "libs": [
                 "/usr/lib"
@@ -130,13 +141,13 @@ class CustomBuildExtension( build_ext ):
 
         # first, search for multiarch files.
         # check if we found more than one version of the multiarch libs.
-        multiarch_libs = dict( [(v,_l) for v, _l in libs.items() \
+        multiarch_libs = dict( [(v,_l) for v, _l in list(libs.items()) \
             if v.find("multiarch") != -1 ] )
         if len(multiarch_libs) > 1:
-        	print "[W] Multiple binutils versions detected. Trying to build with default..."
-            	return multiarch_libs.values()[0]
+                print("[W] Multiple binutils versions detected. Trying to build with default...")
+                return list(multiarch_libs.values())[0]
         if len(multiarch_libs) == 1:
-            return multiarch_libs.values()[0]
+            return list(multiarch_libs.values())[0]
         # or use the default libs, or .. none 
         return libs.get("",[])
 
@@ -171,7 +182,7 @@ class CustomBuildExtension( build_ext ):
 
         libopcodes = [os.path.join(libs_dir,lib) \
             for lib in libs if lib.startswith("libopcodes")][0]
-        print "[+] Detecting libbfd/libopcodes compiled architectures"
+        print("[+] Detecting libbfd/libopcodes compiled architectures")
 
         if self.with_static_binutils: # use the nm from the binutils distro
         
@@ -203,11 +214,11 @@ class CustomBuildExtension( build_ext ):
             self.with_static_binutils == None)
 
         source_bfd_archs_c = generate_supported_architectures_source(supported_archs, supported_machines)
-        print "[+] Generating .C files..."
+        print("[+] Generating .C files...")
         gen_file = os.path.join(PACKAGE_DIR, "gen_bfd_archs.c")
         with open(gen_file, "w+") as fd:
             fd.write(source_bfd_archs_c)
-        print "[+]   %s" % gen_file
+        print("[+]   %s" % gen_file)
 
         if self.with_static_binutils:
            link_to_libs = [] # ...
@@ -232,7 +243,7 @@ class CustomBuildExtension( build_ext ):
                     gen_tool,
                     gen_file  )
 
-        print "[+] Generating .py files..."
+        print("[+] Generating .py files...")
         # generate C dependent definitions
         os.system( cmd )
         # generate python specific data
@@ -244,7 +255,7 @@ class CustomBuildExtension( build_ext ):
             os.unlink(obj)
         os.unlink(gen_tool)
 
-        print "[+]   %s" % gen_file
+        print("[+]   %s" % gen_file)
 
         #
         # Step 3 . Generate header file to be used by the PyBFD extension
@@ -256,11 +267,11 @@ class CustomBuildExtension( build_ext ):
             raise Exception("Unable to determine libopcodes' supported " \
                 "platforms from '%s'" % libopcodes)
 
-        print "[+] Generating .h files..."
+        print("[+] Generating .h files...")
         gen_file = os.path.join(PACKAGE_DIR, "supported_disasm.h")
         with open(gen_file, "w+") as fd:
             fd.write(gen_source)
-        print "[+]   %s" % gen_file
+        print("[+]   %s" % gen_file)
 
         return supported_archs
 
@@ -286,8 +297,8 @@ class CustomBuildExtension( build_ext ):
             raise Exception("unsupported platform: %s" % sys.platform)
 
         if self.with_static_binutils: # the user has specified a custom binutils distro.
-            print "[+] Using specific binutils static distribution"
-            print "[+]   %s" % self.with_static_binutils
+            print("[+] Using specific binutils static distribution")
+            print("[+]   %s" % self.with_static_binutils)
             self.platform["libs"] = [os.path.join( self.with_static_binutils, "lib"),]
             self.platform["includes"] = [os.path.join( self.with_static_binutils, "include"),]
             self.platform["possible-lib-ext"] = [".a",] # for all unix platforms.
@@ -300,15 +311,15 @@ class CustomBuildExtension( build_ext ):
         if self.includes == None:
             raise Exception("unable to determine correct include path for bfd.h / dis-asm.h")
 
-        print "[+] Using binutils headers at:"
-        print "[+]   %s" % self.includes
+        print("[+] Using binutils headers at:")
+        print("[+]   %s" % self.includes)
 
         # we'll use this include path for building.
         ext_includes = [self.includes, ]
 
         # Try to guess libopcodes / libbfd libs.
         libs_dirs = self.platform["libs"]
-        print "[+] Searching binutils libraries..."
+        print("[+] Searching binutils libraries...")
         for libdir in libs_dirs:
             for possible_lib_ext in self.platform["possible-lib-ext"]:
                 libs = self.find_binutils_libs(libdir, possible_lib_ext)
@@ -320,7 +331,7 @@ class CustomBuildExtension( build_ext ):
             raise Exception("unable to find binutils libraries.")
 
         for lib in self.libs[1]:
-            print "[+]   %s" % os.path.join(self.libs[0], lib)
+            print("[+]   %s" % os.path.join(self.libs[0], lib))
         #
         # check for libopcodes / libbfd
         #
@@ -421,7 +432,8 @@ def main():
                 "Operating System :: POSIX",
                 "Programming Language :: C",
                 "Programming Language :: Assembly",
-                "Programming Language :: Python :: 2 :: Only",
+                "Programming Language :: Python :: 2",
+                "Programming Language :: Python :: 3",
                 "Topic :: Security",
                 "Topic :: Software Development :: Disassemblers",
                 "Topic :: Software Development :: Compilers",
@@ -434,15 +446,15 @@ def main():
         
         global final_supported_archs
         if final_supported_archs:
-           print "\n[+] %s %s / Supported architectures:" % (MODULE_NAME, __version__)
+           print("\n[+] %s %s / Supported architectures:" % (MODULE_NAME, __version__))
            for arch, _, _, comment in final_supported_archs:
-               print "\t%-20s : %s" % (arch, comment)
+               print("\t%-20s : %s" % (arch, comment))
 
-    except Exception, err:
+    except Exception as err:
         global debug
         if debug:
             print_exc()
-        print "[-] Error : %s" % err
+        print("[-] Error : %s" % err)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Now pybfd can be successfully built both for Python2 and Python3
It works for Python3 now, too.

Signed-off-by: Vyacheslav Barinov v.barinov@samsung.com
Signed-off-by: Ilya Palachev i.palachev@samsung.com
