### PR TITLE
Fix: Pass 'target' param to underlying bfd functions

### DIFF
--- a/pybfd/bfd.c
+++ b/pybfd/bfd.c
@@ -153,7 +153,7 @@ pybfd_openr(PyObject *self, PyObject *args) {
     const char* target;
 
     if (PyArg_ParseTuple(args, "ss", &filename, &target)) {
-        abfd = bfd_openr(filename, NULL);
+        abfd = bfd_openr(filename, target);
 
         if (!abfd) {
             // An error ocurred trying to open the file.
@@ -191,7 +191,7 @@ pybfd_fdopenr(PyObject *self, PyObject *args) {
     int fd;
 
     if (PyArg_ParseTuple(args, "ssi", &filename, &target, &fd)) {
-        abfd = bfd_fdopenr(filename, NULL, fd);
+        abfd = bfd_fdopenr(filename, target, fd);
 
         if (!abfd) {
             // An error ocurred trying to open the file.

--- a/pybfd/objdump.py
+++ b/pybfd/objdump.py
@@ -48,11 +48,17 @@ class ListFormatAndArchitecturesInformationAction(BfdActionNoParam):
 
         print "%s %s (%s)" % (parser.prog, __version__, __description__)
 
+        print "Architectures:",
         for arch in self.bfd.architectures:
             print " %s" % arch,
+        print
 
+        print
+
+        print "Bfd Targets:",
         for target in self.bfd.targets:
-            print "  %s" % target
+            print " %s" % target,
+        print
 
 
 class BfdActionTarget(Action):

--- a/pybfd/objdump.py
+++ b/pybfd/objdump.py
@@ -55,6 +55,15 @@ class ListFormatAndArchitecturesInformationAction(BfdActionNoParam):
             print "  %s" % target
 
 
+class BfdActionTarget(Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        self.bfd = bfd.Bfd()
+        if values[0] not in self.bfd.targets:
+            raise Exception("Invalid bfd target '%s'" % values[0])
+        namespace.target = values[0]
+        self.bfd.close()
+
+
 class BfdActionWithFileParam(Action):
     """Base class for BFD actions invoked by the argument parser."""
 
@@ -64,7 +73,7 @@ class BfdActionWithFileParam(Action):
         for fd in values:
             try:
                 # Create a new BFD from the current file descriptor.
-                self.bfd = bfd.Bfd(fd)
+                self.bfd = bfd.Bfd(fd, namespace.target)
 
                 # Display current filename and corresponding architecture.
                 print "\n%s:     file format %s\n" % \
@@ -273,6 +282,12 @@ def init_parser():
         action=DumpArchieveHeadersAction,
         type=FileType("r"), nargs="+",
         help="Display archive header information")
+
+    group.add_argument("-b", "--target", # add "-b, --target" to support bfd targets
+        action=BfdActionTarget,
+        nargs="+",
+        default="default",
+        help="")
 
     group.add_argument("-f", "--file-headers",
         action=DumpFileHeadersAction,


### PR DESCRIPTION
Pass 'target' parameter to the underlying bfd functions in the wrapper and use it in the objdump.py script.